### PR TITLE
feat: 出力先の動作をOSによって変更するよう実装

### DIFF
--- a/AI_Assistant_modules/actions/anime_shadow.py
+++ b/AI_Assistant_modules/actions/anime_shadow.py
@@ -40,11 +40,13 @@ class AnimeShadow:
                 with gr.Row():
                     generate_button = gr.Button(lang_util.get_text('generate'), interactive=False)
             with gr.Column():
-                self.output = OutputImage(transfer_target_lang_key)
-                output_image = self.output.layout(lang_util)
+                self.output = OutputImage(self.app_config, transfer_target_lang_key)
+                output_image = self.output.layout()
 
-        input_image.change(lambda x,y: gr.update(interactive=x is not None and y is not None), inputs=[input_image, shadow_image], outputs=[generate_button])
-        shadow_image.change(lambda x,y: gr.update(interactive=x is not None and y is not None), inputs=[input_image, shadow_image], outputs=[generate_button])
+        input_image.change(lambda x, y: gr.update(interactive=x is not None and y is not None),
+                           inputs=[input_image, shadow_image], outputs=[generate_button])
+        shadow_image.change(lambda x, y: gr.update(interactive=x is not None and y is not None),
+                            inputs=[input_image, shadow_image], outputs=[generate_button])
 
         generate_button.click(self._process, inputs=[
             input_image,

--- a/AI_Assistant_modules/actions/i2i.py
+++ b/AI_Assistant_modules/actions/i2i.py
@@ -37,10 +37,13 @@ class Img2Img:
                 with gr.Row():
                     generate_button = gr.Button(lang_util.get_text("generate"), interactive=False)
             with gr.Column():
-                self.output = OutputImage(transfer_target_lang_key)
-                output_image = self.output.layout(lang_util)
-        input_image.change(lambda x: gr.update(interactive=x is not None), inputs=[input_image], outputs=[generate_button])
-        input_image.change(lambda x: gr.update(interactive=x is not None), inputs=[input_image], outputs=[mask_generate_button])
+                self.output = OutputImage(self.app_config, transfer_target_lang_key)
+                output_image = self.output.layout()
+
+        input_image.change(lambda x: gr.update(interactive=x is not None), inputs=[input_image],
+                           outputs=[generate_button])
+        input_image.change(lambda x: gr.update(interactive=x is not None), inputs=[input_image],
+                           outputs=[mask_generate_button])
 
         mask_generate_button.click(mask_process, inputs=[input_image],
                                    outputs=[mask_image])

--- a/AI_Assistant_modules/actions/lighting.py
+++ b/AI_Assistant_modules/actions/lighting.py
@@ -55,10 +55,11 @@ class Lighting:
                 with gr.Row():
                     generate_button = gr.Button(lang_util.get_text("generate"), interactive=False)
             with gr.Column():
-                self.output = OutputImage(transfer_target_lang_key)
-                output_image = self.output.layout(lang_util)
+                self.output = OutputImage(self.app_config, transfer_target_lang_key)
+                output_image = self.output.layout()
 
-        self.input_image.change(lambda x: gr.update(interactive=x is not None), inputs=[self.input_image], outputs=[generate_button])
+        self.input_image.change(lambda x: gr.update(interactive=x is not None), inputs=[self.input_image],
+                                outputs=[generate_button])
         lighting_option.change(self._select_lighting_option, inputs=[lighting_option], outputs=[light_yaw, light_pitch])
 
         generate_button.click(self._process, inputs=[

--- a/AI_Assistant_modules/actions/line_drawing.py
+++ b/AI_Assistant_modules/actions/line_drawing.py
@@ -44,11 +44,15 @@ class LineDrawing:
                 with gr.Row():
                     generate_button = gr.Button(lang_util.get_text("generate"), interactive=False)
             with gr.Column():
-                self.output = OutputImage(transfer_target_lang_key)
-                output_image = self.output.layout(lang_util)
-        self.input_image.change(lambda x,y: gr.update(interactive=x is not None and y is not None), inputs=[self.input_image, canny_image], outputs=[generate_button])
-        canny_image.change(lambda x,y: gr.update(interactive=x is not None and y is not None), inputs=[self.input_image, canny_image], outputs=[generate_button])
-        self.input_image.change(lambda x: gr.update(interactive=x is not None), inputs=[self.input_image], outputs=[canny_generate_button])
+                self.output = OutputImage(self.app_config, transfer_target_lang_key)
+                output_image = self.output.layout()
+
+        self.input_image.change(lambda x, y: gr.update(interactive=x is not None and y is not None),
+                                inputs=[self.input_image, canny_image], outputs=[generate_button])
+        canny_image.change(lambda x, y: gr.update(interactive=x is not None and y is not None),
+                           inputs=[self.input_image, canny_image], outputs=[generate_button])
+        self.input_image.change(lambda x: gr.update(interactive=x is not None), inputs=[self.input_image],
+                                outputs=[canny_generate_button])
 
         canny_generate_button.click(self._make_canny, inputs=[self.input_image, canny_threshold1, canny_threshold2],
                                     outputs=[canny_image])

--- a/AI_Assistant_modules/actions/line_drawing_cutout.py
+++ b/AI_Assistant_modules/actions/line_drawing_cutout.py
@@ -37,10 +37,11 @@ class LineDrawingCutOut:
                 with gr.Row():
                     generate_button = gr.Button(lang_util.get_text("generate"), interactive=False)
             with gr.Column():
-                self.output = OutputImage(transfer_target_lang_key)
-                output_image = self.output.layout(lang_util)
+                self.output = OutputImage(self.app_config, transfer_target_lang_key)
+                output_image = self.output.layout()
 
-        self.input_image.change(lambda x: gr.update(interactive=x is not None), inputs=[self.input_image], outputs=[generate_button])
+        self.input_image.change(lambda x: gr.update(interactive=x is not None), inputs=[self.input_image],
+                                outputs=[generate_button])
 
         generate_button.click(self._process, inputs=[
             self.input_image,

--- a/AI_Assistant_modules/actions/normal_map.py
+++ b/AI_Assistant_modules/actions/normal_map.py
@@ -35,10 +35,11 @@ class NormalMap:
                 with gr.Row():
                     generate_button = gr.Button(lang_util.get_text("generate"), interactive=False)
             with gr.Column():
-                self.output = OutputImage(transfer_target_lang_key)
-                output_image = self.output.layout(lang_util)
+                self.output = OutputImage(self.app_config, transfer_target_lang_key)
+                output_image = self.output.layout()
 
-        self.input_image.change(lambda x: gr.update(interactive=x is not None), inputs=[self.input_image], outputs=[generate_button])
+        self.input_image.change(lambda x: gr.update(interactive=x is not None), inputs=[self.input_image],
+                                outputs=[generate_button])
 
         generate_button.click(self._process, inputs=[
             self.input_image,

--- a/AI_Assistant_modules/actions/resize.py
+++ b/AI_Assistant_modules/actions/resize.py
@@ -34,10 +34,11 @@ class ImageResize:
                 with gr.Row():
                     generate_button = gr.Button(lang_util.get_text("generate"), interactive=False)
             with gr.Column():
-                self.output = OutputImage(transfer_target_lang_key)
-                output_image = self.output.layout(lang_util)
+                self.output = OutputImage(self.app_config, transfer_target_lang_key)
+                output_image = self.output.layout()
 
-        self.input_image.change(lambda x: gr.update(interactive=x is not None), inputs=[self.input_image], outputs=[generate_button])
+        self.input_image.change(lambda x: gr.update(interactive=x is not None), inputs=[self.input_image],
+                                outputs=[generate_button])
 
         generate_button.click(self._process, inputs=[
             self.input_image,

--- a/AI_Assistant_modules/application_config.py
+++ b/AI_Assistant_modules/application_config.py
@@ -1,5 +1,8 @@
 import datetime
 import os
+import sys
+
+from gradio.utils import colab_check, is_zero_gpu_space
 
 
 class ApplicationConfig:
@@ -7,6 +10,19 @@ class ApplicationConfig:
         self.lang_util = lang_util
         self.fastapi_url = None
         self.dpath = dpath
+        self.output_dir = os.path.join(dpath, "output")
+
+        device_mapping = {
+            'darwin': 'mac',
+            'linux': 'linux',
+            'win32': 'windows'
+        }
+        if colab_check() or is_zero_gpu_space() or os.environ.get("GRADIO_CLOUD") == "1":
+            self.device = "cloud"
+        elif os.path.exists('/.dockerenv'):
+            self.device = "docker"
+        else:
+            self.device = device_mapping.get(sys.platform.split()[0], 'unknown')
 
     def set_fastapi_url(self, url):
         self.fastapi_url = url
@@ -14,7 +30,7 @@ class ApplicationConfig:
     def make_output_path(self, filename=None):
         if filename is None:
             filename = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-        output_dir = os.path.join(self.dpath, "output")
-        if not os.path.exists(output_dir):
-            os.makedirs(output_dir)
-        return os.path.join(output_dir, filename + ".png")
+
+        if not os.path.exists(self.output_dir):
+            os.makedirs(self.output_dir)
+        return os.path.join(self.output_dir, filename + ".png")

--- a/AI_Assistant_modules/output_image_gui.py
+++ b/AI_Assistant_modules/output_image_gui.py
@@ -18,25 +18,31 @@ function copyToClipboard() {
 
 
 class OutputImage:
-    def __init__(self, transfer_target_lang_key=None):
+    def __init__(self, app_config, transfer_target_lang_key=None):
+        self.app_config = app_config
         self.transfer_button = None
         self.output_image = None
         self.output_image_path = None
         self.transfer_target_lang_key = transfer_target_lang_key
 
-    def layout(self, lang_util):
+    def layout(self):
+        lang_util = self.app_config.lang_util
         output_image = gr.Image(label=lang_util.get_text("output_image"), interactive=False, type="filepath",
                                 elem_classes=["output-image"])
         output_image.change(self._set_output_image, inputs=[output_image])
-        clipboard_button = gr.Button("" + lang_util.get_text("clipboard"), elem_classes=["clipboard"], interactive=False)
+        clipboard_button = gr.Button("" + lang_util.get_text("clipboard"), elem_classes=["clipboard"],
+                                     interactive=False)
         clipboard_button.click(self._notify, _js=javascript, queue=True)
         if self.transfer_target_lang_key is not None:
             self.transfer_button = gr.Button(lang_util.get_text(self.transfer_target_lang_key), interactive=False)
-            output_image.change(lambda x: gr.update(interactive=x is not None), inputs=[output_image], outputs=[self.transfer_button])
+            output_image.change(lambda x: gr.update(interactive=x is not None), inputs=[output_image],
+                                outputs=[self.transfer_button])
+        if self.app_config.device != "cloud" and self.app_config.device != "docker":
+            gr.Button(lang_util.get_text("output_destination")).click(self._open_output_folder)
 
         self.output_image = output_image
-
-        output_image.change(lambda x: gr.update(interactive=x is not None), inputs=[output_image], outputs=[clipboard_button])
+        output_image.change(lambda x: gr.update(interactive=x is not None), inputs=[output_image],
+                            outputs=[clipboard_button])
 
         return output_image
 
@@ -48,3 +54,12 @@ class OutputImage:
             gr.Warning("Please Image Select")
         else:
             gr.Info("Image Copied to Clipboard")
+
+    def _open_output_folder(self):
+        import subprocess
+        if self.app_config.device == "windows":
+            subprocess.Popen(["explorer", self.app_config.output_dir])
+        elif self.app_config.device == "mac":
+            subprocess.Popen(["open", self.app_config.output_dir])
+        else:
+            subprocess.Popen(["xdg-open", self.app_config.output_dir])

--- a/AI_Assistant_modules/tab_gui.py
+++ b/AI_Assistant_modules/tab_gui.py
@@ -59,10 +59,11 @@ def gradio_tab_gui(app_config):
                 anime_shadow.layout()
             with gr.TabItem(lang_util.get_text("resize")):
                 ImageResize(app_config).layout()
-            with gr.TabItem(lang_util.get_text("output_destination")) as output_tab_item:
-                gallery = gr.Gallery([], label=lang_util.get_text("output_destination"), interactive=False,
-                                     height="85vh")
-                output_tab_item.select(fn=lambda: _open_outputdir(app_config), outputs=[gallery])
+            if app_config.device == "cloud" or app_config.device == "docker":
+                with gr.TabItem(lang_util.get_text("output_destination")) as output_tab_item:
+                    gallery = gr.Gallery([], label=lang_util.get_text("output_destination"), interactive=False,
+                                         height="85vh")
+                    output_tab_item.select(fn=lambda: _open_outputdir(app_config), outputs=[gallery])
 
         # タブ間転送の動作設定
         _set_transfer_button(main_tab, line_drawing_tab_item, img_2_img, line_drawing_tab)


### PR DESCRIPTION
# やったこと
出力先の画像表示について、OSによって動作を変更。

- Windows : エクスプローラーで開く
- Mac: Finderで開く
- Ubuntu等Linux: X Window Systemの標準動作で開く
- Docker、ZeroGPU、Colab : 「出力先」タブを表示しギャラリー表示(変更前の動作)